### PR TITLE
Start transaction manually

### DIFF
--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -43,7 +43,7 @@ class Sql(object):
     sqlCommands = sqlFile.replace('$DATABASE$', database).replace('$PREFIX$', prefix).split(';\n')
 
     # Start a transaction
-    self.db.start_transaction()
+    self.cursor.execute("START TRANSACTION")
 
     # Execute every command from the input file
     for command in sqlCommands:


### PR DESCRIPTION
Apparently, the version of the python MySQL driver we're using doesn't
support the .start_transaction() action.  Instead, do it manually.