### PR TITLE
Add function write_byte

### DIFF
--- a/03-Export-Tags-Authors-Stories.py
+++ b/03-Export-Tags-Authors-Stories.py
@@ -8,6 +8,10 @@ from shared_python.Tags import Tags
 
 
 def write_csv(filename, columns):
+  def write_byte(b):
+    s = str(b)
+    return s[2:len(s)-1]
+  
   html_parser = HTMLParser()
   with open(filename, 'w') as fp:
     myFile = csv.writer(fp)
@@ -15,7 +19,7 @@ def write_csv(filename, columns):
     for row in results:
       r = []
       for s in row:
-        r.append('' if s is None else html.unescape(str(s)).encode('utf-8'))
+        r.append('' if s is None else write_byte(html.unescape(str(s)).encode('utf-8')))
       myFile.writerows([r])
     fp.close()
 


### PR DESCRIPTION
I added a function to convert a byte literal to a string literal by chopping of the b and the extra quotation marks. I did it this way to keep the characters encoded for UTF-8. I'm still not sure why everything is double spaced.