### PR TITLE
OD-610 Use new item_authors table and add note if more than 2 authors

### DIFF
--- a/05-Create-Open-Doors-Tables.py
+++ b/05-Create-Open-Doors-Tables.py
@@ -1,7 +1,6 @@
 # encoding: utf-8
 import os
 
-from automated_archive import aa
 from shared_python.Args import Args
 from shared_python.Chapters import Chapters
 from shared_python.FinalTables import FinalTables
@@ -10,118 +9,118 @@ from shared_python.Tags import Tags
 
 
 def _clean_email(author):
-  email = author['email']
-  if email is None or email == '':
-    email = u'{0}{1}Archive@ao3.org'.format(author['name'], args.archive_name)\
-      .replace(' ', '').replace("'", "")
-  if email.startswith('mailto:'):
-    email = author['email'].replace('mailto:', '')
-  return email
+    """
+    Tidy up author emails that might be missing after earlier stages
+    :param author: row from the authors table
+    :return:
+    """
+    email = author['email']
+    if email is None or email == '':
+        email = u'{0}{1}Archive@ao3.org'.format(author['name'], args.archive_name) \
+            .replace(' ', '').replace("'", "")
+    if email.startswith('mailto:'):
+        email = author['email'].replace('mailto:', '')
+    return email
 
 
 if __name__ == "__main__":
-  args_obj = Args()
-  args = args_obj.args_for_05()
-  log = args_obj.logger_with_filename()
-  sql = Sql(args, log)
-  tags = Tags(args, sql.db, log)
-  final = FinalTables(args, sql.db, log)
-  chaps = Chapters(args, sql.db, log)
+    args_obj = Args()
+    args = args_obj.args_for_05()
+    log = args_obj.logger_with_filename()
+    sql = Sql(args, log)
+    tags = Tags(args, sql.db, log)
+    final = FinalTables(args, sql.db, log)
+    chaps = Chapters(args, sql.db, log)
 
-  coauthors = {}
+    coauthors = {}
 
-  log.info("Creating destination tables in {0}".format(args.output_database))
+    log.info("Creating final destination tables in {0}".format(args.output_database))
 
-  table_names = {
-    'authors': 'authors',
-    'stories': 'stories',
-    'chapters': 'chapters',
-    'story_links': 'story_links'
-  }
-  filter = 'WHERE id NOT IN '
+    table_names = {
+        'authors': 'authors',
+        'stories': 'stories',
+        'chapters': 'chapters',
+        'story_links': 'story_links'
+    }
+    filter = 'WHERE id NOT IN '
 
-  sql.run_script_from_file('shared_python/create-open-doors-tables.sql',
-                           database=args.output_database)
+    sql.run_script_from_file('shared_python/create-open-doors-tables.sql',
+                             database=args.output_database)
 
+    # Filter out DNI stories - story_ids_to_remove must be comma-separated list of DNI ids
+    story_exclusion_filter = ''
+    if os.path.exists(args.story_ids_to_remove):
+        with open(args.story_ids_to_remove, "rt") as f:
+            log.info("Removing {0} Do Not Import stories...".format(sum(line.count(",") for line in f) + 1))
+            f.seek(0)
+            for line in f:
+                story_exclusion_filter = filter + '(' + line + ')'
 
-  story_exclusion_filter = ''
-  # Filter out DNI stories - story_ids_to_remove must be comma-separated list of DNI ids
-  if os.path.exists(args.story_ids_to_remove):
-    with open(args.story_ids_to_remove, "rt") as f:
-      log.info("Removing {0} Do Not Import stories...".format(sum(line.count(",") for line in f) + 1))
-      f.seek(0)
-      for line in f:
-        story_exclusion_filter = filter + '(' + line + ')'
+    # Filter out DNI stories - bookmark_ids_to_remove must be comma-separated list of DNI ids
+    bookmark_exclusion_filter = ''
+    if args.bookmark_ids_to_remove and os.path.exists(args.bookmark_ids_to_remove):
+        with open(args.bookmark_ids_to_remove, "rt") as f:
+            log.info("Removing {0} Do Not Import bookmarks...".format(sum(line.count(",") for line in f) + 1))
+            f.seek(0)
+            for line in f:
+                bookmark_exclusion_filter = filter + '(' + line + ')'
 
-  bookmark_exclusion_filter = ''
-  # Filter out DNI stories - bookmark_ids_to_remove must be comma-separated list of DNI ids
-  if args.bookmark_ids_to_remove and os.path.exists(args.bookmark_ids_to_remove):
-    with open(args.bookmark_ids_to_remove, "rt") as f:
-      log.info("Removing {0} Do Not Import bookmarks...".format(sum(line.count(",") for line in f) + 1))
-      f.seek(0)
-      for line in f:
-        bookmark_exclusion_filter = filter + '(' + line + ')'
+    # Load filtered tables into variables
+    stories_without_tags = final.original_table(table_names['stories'], story_exclusion_filter)
+    log.info("Stories without tags after removing DNI: {0}".format(len(stories_without_tags)))
+    bookmarks_without_tags = final.original_table(table_names['story_links'], bookmark_exclusion_filter)
+    if bookmarks_without_tags:
+        log.info("Bookmarks without tags after removing DNI: {0}".format(len(bookmarks_without_tags)))
+    else:
+        log.info("No bookmarks to remove")
 
+    chapters = final.original_table(table_names['chapters'], '')
 
-  # Export tables
-  stories_without_tags = final.original_table(table_names['stories'], story_exclusion_filter)
-  log.info("Stories without tags after removing DNI: {0}".format(len(stories_without_tags)))
-  bookmarks_without_tags = final.original_table(table_names['story_links'], bookmark_exclusion_filter)
-  if bookmarks_without_tags:
-    log.info("Bookmarks without tags after removing DNI: {0}".format(len(bookmarks_without_tags)))
-  else:
-    log.info("No bookmarks to remove")
-
-  chapters = final.original_table(table_names['chapters'], '')
-
-
-  # ----------------------
-  # AA and custom archives
-  # ----------------------
-  if args.archive_type == 'AA':
     # STORIES
     log.info("Copying stories to final table {0}.stories...".format(args.output_database))
     final_stories = []
     for story in stories_without_tags:
-      # Add additional story processing here
-      final_stories.append(aa.story_to_final_without_tags(story))
+        story_authors = final.original_table('item_authors', f"WHERE item_id={story['id']} and item_type='story'")
+        # Add additional story processing here
+        final_stories.append(final.story_to_final_without_tags(story, story_authors))
     final.insert_into_final('stories', final_stories)
 
     # BOOKMARKS
     if bookmarks_without_tags is not None:
-      log.info("Copying bookmarks to final table {0}.story_links...".format(args.output_database))
-      final_bookmarks = []
-      for bookmark in bookmarks_without_tags:
-        # Add additional bookmark processing here
-        final_bookmarks.append(aa.story_to_final_without_tags(bookmark, False))
-      if final_bookmarks: final.insert_into_final('story_links', final_bookmarks)
+        log.info("Copying bookmarks to final table {0}.story_links...".format(args.output_database))
+        final_bookmarks = []
+        for bookmark in bookmarks_without_tags:
+            # Add additional bookmark processing here
+            bookmark_authors = final.original_table('item_authors',
+                                                    f"WHERE item_id={bookmark['id']} and item_type='story_link'")
+            final_bookmarks.append(final.story_to_final_without_tags(bookmark, bookmark_authors, False))
+        if final_bookmarks: final.insert_into_final('story_links', final_bookmarks)
 
     # AUTHORS
-    log.info("Copying authors to final table {0}.authors, cleaning emails and removing authors with no works...".format(args.output_database))
+    log.info("Copying authors to final table {0}.authors, cleaning emails and removing authors with no works...".format(
+        args.output_database))
     final_authors = []
     authors = final.original_table(table_names['authors'])
     for final_author in authors:
-      if any(story['author_id'] == final_author['id'] or story['coauthor_id'] == final_author['id'] for story in final_stories)\
-          or any(bookmark['author_id'] == final_author['id'] for bookmark in final_bookmarks):
-        final_author['email'] = _clean_email(final_author)
-        final_authors.append(final_author)
+        if any(story['author_id'] == final_author['id'] or story['coauthor_id'] == final_author['id'] for story in
+               final_stories) \
+                or any(bookmark['author_id'] == final_author['id'] for bookmark in final_bookmarks):
+            final_author['email'] = _clean_email(final_author)
+            final_authors.append(final_author)
     final.insert_into_final('authors', final_authors)
 
     # CHAPTERS
     if chapters:
-      dest_chapter_table = "{0}.{1}".format(args.output_database, table_names['chapters'])
-      log.info("Copying chapters table {0} from source chapters table...".format(dest_chapter_table))
-      sql.execute("drop table if exists {0}".format(dest_chapter_table))
+        dest_chapter_table = f"{args.output_database}.{table_names['chapters']}"
+        log.info("Copying chapters table {0} from source chapters table...".format(dest_chapter_table))
+        sql.execute("drop table if exists {0}".format(dest_chapter_table))
 
-      truncate_and_insert = "create table {0} select * from {1}.{2}".format(
-        dest_chapter_table,
-        args.temp_db_database,
-        table_names['chapters'])
-      sql.execute(truncate_and_insert)
+        truncate_and_insert = "create table {0} select * from {1}.{2}".format(
+            dest_chapter_table,
+            args.temp_db_database,
+            table_names['chapters'])
+        sql.execute(truncate_and_insert)
     else:
-      log.info("Creating chapters table {0}.chapters from source stories table...".format(args.output_database))
-      final_chapters = aa.dummy_chapters(final_stories)
-      final.insert_into_final('chapters', final_chapters)
-
-
-
+        log.info("Creating chapters table {0}.chapters from source stories table...".format(args.output_database))
+        final_chapters = final.dummy_chapters(final_stories)
+        final.insert_into_final('chapters', final_chapters)

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -227,45 +227,6 @@ def clean_and_load_data(args, log):
   _create_mysql(args, data, log)
 
 
-def story_to_final_without_tags(story, is_story = True):
-  final_story = {
-    'id':            story['id'],
-    'title':         story['title'],
-    'summary ':      story['summary'],
-    'notes':         story['notes'],
-    'author_id':     story['author_id'],
-    'date':          story['date'],
-    'updated':       story['updated'],
-    'url':           story['url'],
-    'ao3_url':       story['ao3_url'],
-    'imported':      0,
-    'do_not_import':   0,
-  }
-  if is_story:
-    final_story['coauthor_id'] = story['coauthor_id']
-  return final_story
-
-
-def dummy_chapters(stories):
-  return [_dummy_chapter(story) for story in stories]
-
-
-def _dummy_chapter(story):
-  chapter = {k.lower(): v for k, v in story.iteritems()}
-  final_chapter = {
-    'id':       chapter['id'],
-    'position': chapter.get('position', 1),
-    'title':    chapter['title'],
-    'author_id': chapter['author_id'],
-    'text':     chapter.get('text', ''),
-    'date':     chapter['date'],
-    'story_id':  chapter['id'],
-    'notes':    chapter['notes'],
-    'url':      chapter['url']
-  }
-  return final_chapter
-
-
 if __name__ == "__main__":
   args = Args().process_args()
   data = _clean_file(args.filepath)

--- a/shared_python/FinalTables.py
+++ b/shared_python/FinalTables.py
@@ -1,80 +1,118 @@
-from html.parser import HTMLParser
-
 import datetime
+import html
+from logging import Logger
 
 from pymysql import cursors
 
 
 class FinalTables(object):
 
-  def __init__(self, args, db, log):
-    self.args = args
-    self.db = db
-    self.dict_cursor = self.db.cursor(cursors.DictCursor)
-    self.original_database = args.temp_db_database
-    self.final_database = args.output_database
-    self.html_parser = HTMLParser()
-    self.log = log
+    def __init__(self, args, db, log: Logger):
+        self.args = args
+        self.db = db
+        self.dict_cursor = self.db.cursor(cursors.DictCursor)
+        self.original_database = args.temp_db_database
+        self.final_database = args.output_database
+        self.log = log
 
+    def original_table(self, table_name, filter='', database_name=None):
+        if table_name is None:
+            return None
+        if database_name is None:
+            original_database = self.original_database
+        else:
+            original_database = database_name
+        query = "SELECT * FROM `{0}`.`{1}` {2}".format(original_database, table_name, filter)
+        self.dict_cursor.execute(query)
+        return self.dict_cursor.fetchall()
 
-  def original_table(self, table_name, filter = '', database_name = None):
-    if table_name is None:
-      return None
-    if database_name is None:
-      original_database = self.original_database
-    else:
-      original_database = database_name
-    query = "SELECT * FROM `{0}`.`{1}` {2}".format(original_database, table_name, filter)
-    self.dict_cursor.execute(query)
-    return self.dict_cursor.fetchall()
+    def _escape_unescape(self, item):
+        return html.unescape(item).replace('\\', '\\\\').replace('"', '\\"').replace("'", "\\'")
 
+    def _value(self, row):
+        value = []
+        for item in row:
+            if type(item) is str:
+                value.append('"' + self._escape_unescape(item) + '"')
+            elif type(item) is datetime.datetime:
+                value.append('"' + str(item) + '"')
+            elif item is None:
+                value.append('null')
+            elif item == '':
+                value.append('""')
+            else:
+                value.append(str(item))
+        return value
 
-  def _escape_unescape(self, item):
-    return self.html_parser.unescape(item).replace('\\', '\\\\').replace('"', '\\"').replace("'", "\\'")
+    def insert_into_final(self, output_table_name, rows, target_database=None):
+        if target_database:
+            final_database = target_database
+        else:
+            final_database = self.final_database
+        self.dict_cursor.execute("TRUNCATE `{0}`.`{1}`".format(final_database, output_table_name))
+        columns = rows[0].keys()
+        values = []
+        for row in rows:
+            col = self._value(row.values())
+            values.append('(' + ', '.join(col) + ')')
 
+        self.dict_cursor.execute(f"""
+            INSERT INTO `{final_database}`.`{output_table_name}` ({', '.join(columns)}) VALUES {', '.join(values)}
+          """)
+        self.db.commit()
 
-  def _value(self, row):
-    value = []
-    for item in row:
-      if type(item) is str:
-        value.append('"' + self._escape_unescape(item) + '"')
-      elif type(item) is datetime.datetime:
-        value.append('"' + str(item) + '"')
-      elif item is None:
-        value.append('null')
-      elif item == '':
-        value.append('""')
-      else:
-        value.append(item)
-    return value
+    def populate_story_tags(self, story_id, output_table_name, story_tags):
+        cols_with_tags = []
+        for (col, tags) in story_tags.items():
+            cols_with_tags.append(u"{0}='{1}'".format(col, tags.replace("'", "\\'").strip()))
 
-
-  def insert_into_final(self, output_table_name, rows, target_database = None):
-    if target_database:
-      final_database = target_database
-    else:
-      final_database = self.final_database
-    self.dict_cursor.execute("TRUNCATE `{0}`.`{1}`".format(final_database, output_table_name))
-    columns = rows[0].keys()
-    values = []
-    for row in rows:
-      r = self._value(row.values())
-      values.append('(' + u', '.join(r) + ')')
-
-    self.dict_cursor.execute(u"""
-       INSERT INTO `{0}`.`{1}` ({2})
-       VALUES {3}
-      """.format(final_database, output_table_name, ', '.join(columns), u', '.join(values)))
-    self.db.commit()
-
-
-  def populate_story_tags(self, story_id, output_table_name, story_tags):
-    cols_with_tags = []
-    for (col, tags) in story_tags.items():
-      cols_with_tags.append(u"{0}='{1}'".format(col, tags.replace("'", "\\'").strip()))
-
-    if cols_with_tags:
-      self.dict_cursor.execute(u"""
+        if cols_with_tags:
+            self.dict_cursor.execute("""
          UPDATE `{0}`.`{1}` SET {2} WHERE id={3}
         """.format(self.final_database, output_table_name, ", ".join(cols_with_tags), story_id))
-      self.db.commit()
+            self.db.commit()
+
+    def story_to_final_without_tags(self, story, story_authors, is_story=True):
+        type = 'story' if is_story else 'story_link'
+        authors_count = len(story_authors)
+        notes = story['notes']
+        if authors_count > 2:
+            # AO3 works can't currently be imported with more than two authors
+            self.log.warning(f"{type} {story['id']} has {authors_count} authors - listing all authors in notes...")
+            author_names = "Creators: {} and {}".format(", ".join(story_authors[:-1]),  story_authors[-1])
+            notes = "{author_names}<br/><br/>{notes}" if notes else author_names
+
+        final_story = {
+            'id': story['id'],
+            'title': story['title'],
+            'summary ': story['summary'],
+            'notes': notes,
+            'author_id': story_authors[0]["author_id"],
+            'date': story['date'],
+            'updated': story['updated'],
+            'url': story['url'],
+            'ao3_url': story['ao3_url'],
+            'imported': 0,
+            'do_not_import': 0,
+        }
+        if is_story:
+            # AO3 bookmarks can't currently be imported with multiple authors, so only populate the coauthor for works
+            final_story['coauthor_id'] = story_authors[1]["author_id"] if authors_count > 1 else None
+        return final_story
+
+    def dummy_chapters(self, stories):
+        return [self._dummy_chapter(story) for story in stories]
+
+    def _dummy_chapter(self, story):
+        chapter = {k.lower(): v for k, v in story.iteritems()}
+        final_chapter = {
+            'id': chapter['id'],
+            'position': chapter.get('position', 1),
+            'title': chapter['title'],
+            'text': chapter.get('text', ''),
+            'date': chapter['date'],
+            'story_id': chapter['id'],
+            'notes': chapter['notes'],
+            'url': chapter['url']
+        }
+        return final_chapter


### PR DESCRIPTION
**Problem**
The eFiction process was recently updated to use an item_authors table allowing an unbounded number of authors to be attached to a work. Sadly, the AO3 import process still only allows two authors, so ODAP step 05 needs to use the join table to populate the available fields in the temp site tables.

**Solution**
Grab the first two authors in the join table and populate the author and coauthor fields for stories, and the author field for story_links. 
So that we don't lose the information about other authors for readers, include all the author names at the start of the story notes.

(Also removes some references to AA as all archives are using the same code now)
