### PR TITLE
Fix mapping a single original tag to multiple AO3 tags

### DIFF
--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -100,6 +100,7 @@ class Tags(object):
       SELECT DISTINCT
         id as "Original Tag ID",
         original_tag as "Original Tag Name",
+        original_type as "Original Tag Type",
         original_parent as "Original Parent Tag",
         ao3_tag_fandom as "Related Fandom",
         ao3_tag as "Recommended AO3 Tag",

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -176,5 +176,17 @@ class Tags(object):
       sys.stdout.flush()
 
       tags = self.sql.execute_dict(f"SELECT * FROM tags WHERE id in ({story_id[2]})")
+      
+      ### add additional tags if original_tag is split into multiple ao3 tags
+      new_tags = []
+      keys = ', '.join(['original_tagid', 'original_tag', 'original_type', 
+                        'original_parent', 'original_description', 'ao3_tag', 
+                        'ao3_tag_type', 'ao3_tag_category', 'ao3_tag_fandom'])
+      for tag in tags:
+        original_tagid, original_tag = tag['id'], tag['original_tag']
+        extra_tags = self.sql.execute_dict(f"""SELECT DISTINCT  {keys} from tags where original_tagid = {original_tagid} AND original_tag = '{original_tag}'""")
+        new_tags.extend(extra_tags)
+      tags.extend(new_tags)
+      
       tags_by_story_id[story_id[0]] = tags
     return tags_by_story_id


### PR DESCRIPTION
When populate the tags, the `id` [here](https://github.com/otwcode/open-doors-code/blob/58022bd4db02e0b152e0476ba23e7b87b4d20fe2/shared_python/Tags.py#L178) only contains the first corresponding AO3 tag, when it should be mapped to multiple AO3 tags. 

Instead of selecting by the `id`, select by the combination of `original_tagid` and `original_tag`, this will include additional mapped tags. The reason not selecting by `id` is that when update the Tags table, the `id` of these additional tags are automatically incremented, which is not tracked in other tables.