### PR TITLE
OD 629

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ setuptools_svn==1.2
 wincertstore==0.2
 pyxdg==0.27
 pyyaml==5.4
+chardet==3.0.4

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -108,14 +108,18 @@ class Chapters(object):
             encoding = chardet.detect(file_contents)
             if encoding['confidence'] < 0.7:
                 print(f" Low confidence in {encoding['encoding']} in file {chapter_path}", flush=True)
-            file_contents = file_contents.decode(encoding=encoding['encoding'])
+                file_contents = file_contents.decode(encoding=encoding['encoding'], errors='ignore')
+            else:
+                file_contents = file_contents.decode(encoding=encoding['encoding'])
             query = "UPDATE {0}.chapters SET text=%s WHERE id=%s".format(self.args.output_database)
             self.sql.execute(query, (file_contents, int(cid)))
           except Exception as e:
+            # TODO maybe display where encoding fault is?
             self.log.error("Error = chapter id: {0} - chapter: {1}\n{2}".format(cid, chapter_path, str(e)))
           finally:
             pass
     else:
+      # TODO add encoding detection here
       for _, chapter_path in file_paths.items():
         path = chapter_path.replace(self.args.chapters_path, '')[1:]
         with codecs.open(chapter_path, 'r', encoding=char_encoding) as c:

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -1,6 +1,5 @@
 # -- coding: utf-8 --
 
-#import codecs
 import os
 import re
 import chardet


### PR DESCRIPTION
# Changes:

- Step 2a no longer asks for the file encoding, instead it uses chardet to pick one automaticly.
- When it nevertheless encounters a invalid byte, it is discarded, and the changes are shown in context:
```
1639/1644 stories Low confidence in Windows-1254 in file /home/ubuntu/otw_opendoors/tests/weaverofdreams/stories/468/1840.txt: 60%

Failed to decode /home/ubuntu/otw_opendoors/tests/weaverofdreams/stories/468/1840.txt
At line 4:	'charmap' codec can't decode byte 0x9d in position 1598: character maps to <undefined>
--	b'You"</em></p>\r\n<p align="center">&acirc;\x9d&brvbar;</p>\r\n<p align="left">'
	                                            ^^^^
Will be converted to:
++	  You"</em></p>\r\n<p align="center">&acirc;&brvbar;</p>\r\n<p align="left">E
```
The offending byte is underlined with `^`.