### PR TITLE
OD-700 Final Chapter missing an index (+ others)

### DIFF
--- a/.github/workflows/python-app-macos-windows.yml
+++ b/.github/workflows/python-app-macos-windows.yml
@@ -37,4 +37,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest - exclude MySQL integration tests
         run: |
-          pytest --ignore "test/test_multitag_mapping.py" --ignore "test/test_percent_symbol.py" --ignore "test/test_tags_length.py" 
+          pytest --ignore "test/test_multitag_mapping.py" --ignore "test/test_percent_symbol.py" --ignore "test/test_tags_length.py" --ignore "test/test_step_05.py"

--- a/05-Create-Open-Doors-Tables.py
+++ b/05-Create-Open-Doors-Tables.py
@@ -23,16 +23,9 @@ def _clean_email(author):
     return email
 
 
-if __name__ == "__main__":
-    args_obj = Args()
-    args = args_obj.args_for_05()
-    log = args_obj.logger_with_filename()
+def main(args, log):
     sql = Sql(args, log)
-    tags = Tags(args, sql, log)
     final = FinalTables(args, sql, log)
-    chaps = Chapters(args, sql, log)
-
-    coauthors = {}
 
     log.info("Creating final destination tables in {0}".format(args.output_database))
 
@@ -126,3 +119,9 @@ if __name__ == "__main__":
         log.info("Creating chapters table {0}.chapters from source stories table...".format(args.output_database))
         final_chapters = final.dummy_chapters(final_stories)
         final.insert_into_final('chapters', final_chapters)
+
+if __name__ == "__main__":
+    args_obj = Args()
+    args = args_obj.args_for_05()
+    log = args_obj.logger_with_filename()
+    main(args, log)

--- a/05-Create-Open-Doors-Tables.py
+++ b/05-Create-Open-Doors-Tables.py
@@ -74,8 +74,6 @@ if __name__ == "__main__":
     else:
         log.info("No bookmarks to remove")
 
-    chapters = final.original_table(table_names['chapters'], '')
-
     # STORIES
     log.info("Copying stories to final table {0}.stories...".format(args.output_database))
     final_stories = []
@@ -110,16 +108,20 @@ if __name__ == "__main__":
     final.insert_into_final('authors', final_authors)
 
     # CHAPTERS
+    chapters = final.original_table(table_names['chapters'], '')
     if chapters:
         dest_chapter_table = f"{args.output_database}.{table_names['chapters']}"
         log.info("Copying chapters table {0} from source chapters table...".format(dest_chapter_table))
         sql.execute("drop table if exists {0}".format(dest_chapter_table))
 
-        truncate_and_insert = "create table {0} select * from {1}.{2}".format(
+        truncate_and_insert = "create table {0} (unique(id), key(story_id)) select * from {1}.{2}".format(
             dest_chapter_table,
             args.temp_db_database,
             table_names['chapters'])
         sql.execute(truncate_and_insert)
+
+        add_auto_increment = "alter table {0} modify id int not null auto_increment".format(dest_chapter_table)
+        sql.execute(add_auto_increment)
     else:
         log.info("Creating chapters table {0}.chapters from source stories table...".format(args.output_database))
         final_chapters = final.dummy_chapters(final_stories)

--- a/shared_python/FinalTables.py
+++ b/shared_python/FinalTables.py
@@ -100,7 +100,7 @@ class FinalTables(object):
         return [self._dummy_chapter(story) for story in stories]
 
     def _dummy_chapter(self, story):
-        chapter = {k.lower(): v for k, v in story.iteritems()}
+        chapter = {k.lower(): v for k, v in story.items()}
         final_chapter = {
             'id': chapter['id'],
             'position': chapter.get('position', 1),

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -51,8 +51,6 @@ class Sql(object):
     sqlFile = fd.read()
     fd.close()
 
-    # remove all comments
-    sqlFile = re.sub(r'(--|#|\/\*).*?\n', '', sqlFile)
     # replace placeholders and return all SQL commands (split on ';')
     sqlCommands = sqlFile.replace('$DATABASE$', database).split(';\n')
 
@@ -67,7 +65,9 @@ class Sql(object):
       # For example, if the tables do not yet exist, this will skip over
       # the DROP TABLE commands
       try:
-        lc_command = command.lower().strip().replace("\n", "")
+        # Strip out commented out lines
+        end_command = re.sub(r'(--|#|\/\*).*?\n', '', command)
+        lc_command = end_command.lower().strip().replace("\n", "")
         if initial_load and (lc_command.startswith("create database ") or lc_command.startswith("use ")):
           self.log.info("Skipping command - {0}".format(lc_command))
         elif lc_command is None or lc_command == '':

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -51,6 +51,8 @@ class Sql(object):
     sqlFile = fd.read()
     fd.close()
 
+    # remove all comments
+    sqlFile = re.sub(r'(--|#|\/\*).*?\n', '', sqlFile)
     # replace placeholders and return all SQL commands (split on ';')
     sqlCommands = sqlFile.replace('$DATABASE$', database).split(';\n')
 
@@ -65,15 +67,13 @@ class Sql(object):
       # For example, if the tables do not yet exist, this will skip over
       # the DROP TABLE commands
       try:
-        # Strip out commented out lines
-        end_command = re.sub(r'(--|#|/*).*?\n', '', command)
-        lc_command = end_command.lower().strip().replace("\n", "")
+        lc_command = command.lower().strip().replace("\n", "")
         if initial_load and (lc_command.startswith("create database ") or lc_command.startswith("use ")):
           self.log.info("Skipping command - {0}".format(lc_command))
         elif lc_command is None or lc_command == '':
           self.log.info(lc_command)
         else:
-          self.cursor.execute(command)
+          self.cursor.execute(lc_command)
       except OperationalError as e:
         self.log.info("Command skipped: {0} [{1}]".format(command, e))
 

--- a/test/test_data/test.sql
+++ b/test/test_data/test.sql
@@ -8,7 +8,7 @@ CREATE TABLE item_tags (
   `tag_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`)
-) -- ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+);
 
 INSERT INTO item_tags VALUES (1,333,'story',10),(2,444,'story',10),(3,333,'story',11),(4,444,'story',11),(5,555,'story',11);
 
@@ -25,6 +25,6 @@ CREATE TABLE tags (
   `ao3_tag_fandom` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_UNIQUE` (`id`)
-) -- ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb3;
+);
 
 INSERT INTO tags VALUES (10,989,'original-tag-1','classes',NULL,'','','','',''),(11,345,'original-tag-2','classes',NULL,'','','','','');

--- a/test/test_data/test_working_tables.sql
+++ b/test/test_data/test_working_tables.sql
@@ -1,0 +1,153 @@
+DROP DATABASE IF EXISTS $DATABASE$;
+CREATE DATABASE $DATABASE$;
+USE $DATABASE$;
+
+CREATE TABLE IF NOT EXISTS `authors` (
+    `id`            int(11)      NOT NULL AUTO_INCREMENT,
+    `name`          varchar(255) NOT NULL DEFAULT '',
+    `email`         varchar(255) NOT NULL DEFAULT '',
+    `imported`      tinyint(1)   NOT NULL DEFAULT '0',
+    `do_not_import` tinyint(1)   NOT NULL DEFAULT '0',
+    `to_delete`     tinyint(1)            DEFAULT '0',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+  
+INSERT INTO `authors` (`id`, `name`, `email`, `imported`, `do_not_import`, `to_delete`) VALUES 
+(1,'Author 1','test1@opendoors.org',0,0,0),
+(2,'Author 2','test2@opendoors.org',0,0,0),
+(3,'Author 3','test3@opendoors.org',0,0,0),
+(4,'Author 4','test4@opendoors.org',0,0,0),
+(5,'Author 5','test5@opendoors.org',0,0,0);
+
+CREATE TABLE IF NOT EXISTS `chapters` (
+    `id`       int(11)      NOT NULL AUTO_INCREMENT,
+    `position` bigint(22)            DEFAULT NULL,
+    `title`    varchar(255) NOT NULL DEFAULT '',
+    `text`     mediumtext,
+    `date`     datetime              DEFAULT NULL,
+    `story_id` int(11)               DEFAULT '0',
+    `notes`    text,
+    `url`      varchar(1024)         DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`),
+    KEY `storyid` (`story_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `chapters` (`id`, `position`, `title`, `text`, `date`, `story_id`, `notes`, `url`) VALUES 
+(1,1,'Chapter 1','',NULL,1,'',NULL),
+(2,1,'Chapter 1','',NULL,2,'',NULL),
+(3,1,'Chapter 1','',NULL,3,'',NULL),
+(4,1,'Chapter 1','',NULL,4,'',NULL),
+(5,1,'Chapter 1','',NULL,5,'',NULL);
+
+CREATE TABLE IF NOT EXISTS `item_authors` (
+    `id`        int(11) NOT NULL AUTO_INCREMENT,
+    `author_id` int(11) NOT NULL,
+    `item_id`   int(11) NOT NULL,
+    `item_type` ENUM ('story', 'story_link', 'chapter'),
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`),
+    KEY `item_id` (`item_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `item_authors` (`id`, `author_id`, `item_id`, `item_type`) VALUES 
+(1,1,1,'story'),
+(2,2,2,'story'),
+(3,3,3,'story'),
+(4,4,4,'story'),
+(5,5,5,'story');
+
+CREATE TABLE IF NOT EXISTS `item_tags` (
+    `id`        int(11) NOT NULL AUTO_INCREMENT,
+    `item_id`   int(11),
+    `item_type` ENUM ('story', 'story_link', 'chapter'),
+    `tag_id`    int(11),
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `item_tags` (`id`, `item_id`, `item_type`, `tag_id`) VALUES 
+(1,1,'story',1),
+(2,2,'story',2),
+(3,3,'story',3),
+(4,4,'story',4),
+(5,5,'story',5);
+
+CREATE TABLE IF NOT EXISTS `stories` (
+    `id`            int(11)      NOT NULL AUTO_INCREMENT,
+    `title`         varchar(255) NOT NULL DEFAULT '',
+    `summary`       text,
+    `notes`         text,
+    `date`          datetime              DEFAULT NULL,
+    `updated`       datetime              DEFAULT NULL,
+    `categories`    varchar(45)           DEFAULT NULL,
+    `tags`          varchar(255) NOT NULL DEFAULT '',
+    `warnings`      varchar(255)          DEFAULT '',
+    `fandoms`       varchar(255)          DEFAULT '',
+    `characters`    varchar(1024)         DEFAULT '',
+    `relationships` varchar(1024)         DEFAULT '',
+    `language_code` varchar(5)            DEFAULT 'en',
+    `url`           varchar(255)          DEFAULT NULL,
+    `imported`      tinyint(1)   NOT NULL DEFAULT '0',
+    `do_not_import` tinyint(1)   NOT NULL DEFAULT '0',
+    `ao3_url`       varchar(255)          DEFAULT NULL,
+    `import_notes`  varchar(1024)         DEFAULT '',
+    `rating`        varchar(21)           DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `stories` (`id`, `title`, `summary`, `notes`, `date`, `updated`, `categories`, `tags`, `warnings`, `fandoms`, `characters`, `relationships`, `language_code`, `url`, `imported`, `do_not_import`, `ao3_url`, `import_notes`, `rating`) VALUES 
+(1,'Story 1','Summary 1','','2004-07-01 18:10:04','2004-07-01 18:59:02',NULL,'','','','','','',NULL,0,0,NULL,'',NULL),
+(2,'Story 2','Summary 2','','2004-07-01 19:33:10','2004-07-01 21:43:45',NULL,'','','','','','',NULL,0,0,NULL,'',NULL),
+(3,'Story 3','Summary 3','','2004-07-01 21:54:47','2004-07-24 20:24:38',NULL,'','','','','','',NULL,0,0,NULL,'',NULL),
+(4,'Story 4','Summary 4','','2004-07-01 22:04:33','2004-07-24 22:05:42',NULL,'','','','','','',NULL,0,0,NULL,'',NULL),
+(5,'Story 5','Summary 5','','2004-07-04 14:32:24','2004-07-04 14:32:24',NULL,'','','','','','',NULL,0,0,NULL,'',NULL);
+
+CREATE TABLE IF NOT EXISTS `story_links` (
+    `id`            int(11)      NOT NULL AUTO_INCREMENT,
+    `title`         varchar(255) NOT NULL DEFAULT '',
+    `summary`       text,
+    `notes`         text,
+    `rating`        varchar(255) NOT NULL DEFAULT '',
+    `date`          datetime              DEFAULT NULL,
+    `updated`       datetime              DEFAULT NULL,
+    `categories`    varchar(45)           DEFAULT NULL,
+    `tags`          varchar(255) NOT NULL DEFAULT '',
+    `warnings`      varchar(255)          DEFAULT '',
+    `fandoms`       varchar(255)          DEFAULT '',
+    `characters`    varchar(1024)         DEFAULT '',
+    `relationships` varchar(1024)         DEFAULT '',
+    `language_code` varchar(5)            DEFAULT 'en',
+    `url`           varchar(255)          DEFAULT NULL,
+    `imported`      tinyint(1)   NOT NULL DEFAULT '0',
+    `do_not_import` tinyint(1)   NOT NULL DEFAULT '0',
+    `ao3_url`       varchar(255)          DEFAULT NULL,
+    `broken_link`   tinyint(1)   NOT NULL DEFAULT '0',
+    `import_notes`  varchar(1024)         DEFAULT '',
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `tags` (
+    `id`                   int(11) AUTO_INCREMENT,
+    `original_tagid`       int(11)       DEFAULT NULL,
+    `original_tag`         varchar(1024) DEFAULT NULL,
+    `original_type`        varchar(255)  DEFAULT NULL,
+    `original_parent`      varchar(255)  DEFAULT NULL,
+    `original_description` varchar(1024) DEFAULT NULL,
+    `ao3_tag`              varchar(1024) DEFAULT NULL,
+    `ao3_tag_type`         varchar(255)  DEFAULT NULL,
+    `ao3_tag_category`     varchar(255)  DEFAULT NULL,
+    `ao3_tag_fandom`       varchar(255)  DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `id_UNIQUE` (`id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+  
+INSERT INTO `tags` (`id`, `original_tagid`, `original_tag`, `original_type`, `original_parent`, `original_description`, `ao3_tag`, `ao3_tag_type`, `ao3_tag_category`, `ao3_tag_fandom`) VALUES 
+(1,1,'G','rating',NULL,'General Audience',NULL,NULL,NULL,NULL),
+(2,2,'PG','rating',NULL,'Parental Guidance Suggested',NULL,NULL,NULL,NULL),
+(3,3,'PG-13','rating',NULL,'Parents Strongly Cautioned',NULL,NULL,NULL,NULL),
+(4,4,'R','rating',NULL,'Restricted-Under 17',NULL,NULL,NULL,NULL),
+(5,5,'NC-17','rating',NULL,'No One 17 and Under Admitted',NULL,NULL,NULL,NULL);

--- a/test/test_step_05.py
+++ b/test/test_step_05.py
@@ -1,0 +1,59 @@
+from collections import defaultdict
+from unittest import TestCase
+import unittest
+from unittest.mock import MagicMock
+from shared_python.Sql import Sql
+from shared_python.Logging import logger
+import argparse
+
+import sys
+import os
+import importlib
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+step_05 = importlib.import_module("05-Create-Open-Doors-Tables")
+
+def testArgs():
+	parser = argparse.ArgumentParser(description='Test an archive database')
+	args = parser.parse_args()
+	setattr(args, "archive_type", "AA")
+	setattr(args, "db_host", "localhost")
+	setattr(args, "db_user", "root")
+	setattr(args, "db_password", "test")
+	setattr(args, "temp_db_database", "test_working_step_five")
+	setattr(args, "output_database", "unit_test_step_five")
+	setattr(args, "default_fandom", "Fandom C (TV)")
+	setattr(args, "sql_path", "./test/test_data/test_working_tables.sql")
+	setattr(args, "story_ids_to_remove", "")
+	setattr(args, "bookmark_ids_to_remove", "")
+	return args
+
+class TestStepFive(TestCase):
+	args = testArgs()
+	log = logger("test")
+	sql = Sql(args, log)
+	sql.run_script_from_file(args.sql_path, args.temp_db_database, initial_load=False)
+
+	def test_chapter_table_structure(self):
+		step_05.main(self.args, self.log)
+
+		get_indexes = "show index from {}.chapters".format(self.args.output_database)
+		result = self.sql.execute_dict(get_indexes)
+
+		col_indexes = defaultdict(list)
+		for index in result:
+			col_indexes[index["Column_name"]].append(index)
+		self.assertGreaterEqual(len(col_indexes["id"]), 1)
+		self.assertEqual(len(col_indexes["story_id"]), 1)
+
+	def tearDown(self):
+		drop_working = "drop database {}".format(self.args.temp_db_database)
+		self.sql.execute(drop_working)
+		drop_final = "drop database {}".format(self.args.output_database)
+		self.sql.execute(drop_final)
+
+if __name__ == '__main__':
+	unittest.main()

--- a/test/test_step_05.py
+++ b/test/test_step_05.py
@@ -17,43 +17,43 @@ sys.path.append(parent)
 step_05 = importlib.import_module("05-Create-Open-Doors-Tables")
 
 def testArgs():
-	parser = argparse.ArgumentParser(description='Test an archive database')
-	args = parser.parse_args()
-	setattr(args, "archive_type", "AA")
-	setattr(args, "db_host", "localhost")
-	setattr(args, "db_user", "root")
-	setattr(args, "db_password", "test")
-	setattr(args, "temp_db_database", "test_working_step_five")
-	setattr(args, "output_database", "unit_test_step_five")
-	setattr(args, "default_fandom", "Fandom C (TV)")
-	setattr(args, "sql_path", "./test/test_data/test_working_tables.sql")
-	setattr(args, "story_ids_to_remove", "")
-	setattr(args, "bookmark_ids_to_remove", "")
-	return args
+    parser = argparse.ArgumentParser(description='Test an archive database')
+    args = parser.parse_args()
+    setattr(args, "archive_type", "AA")
+    setattr(args, "db_host", "localhost")
+    setattr(args, "db_user", "root")
+    setattr(args, "db_password", "test")
+    setattr(args, "temp_db_database", "test_working_step_five")
+    setattr(args, "output_database", "unit_test_step_five")
+    setattr(args, "default_fandom", "Fandom C (TV)")
+    setattr(args, "sql_path", "./test/test_data/test_working_tables.sql")
+    setattr(args, "story_ids_to_remove", "")
+    setattr(args, "bookmark_ids_to_remove", "")
+    return args
 
 class TestStepFive(TestCase):
-	args = testArgs()
-	log = logger("test")
-	sql = Sql(args, log)
-	sql.run_script_from_file(args.sql_path, args.temp_db_database, initial_load=False)
+    args = testArgs()
+    log = logger("test")
+    sql = Sql(args, log)
+    sql.run_script_from_file(args.sql_path, args.temp_db_database, initial_load=False)
 
-	def test_chapter_table_structure(self):
-		step_05.main(self.args, self.log)
+    def test_chapter_table_structure(self):
+        step_05.main(self.args, self.log)
 
-		get_indexes = "show index from {}.chapters".format(self.args.output_database)
-		result = self.sql.execute_dict(get_indexes)
+        get_indexes = "show index from {}.chapters".format(self.args.output_database)
+        result = self.sql.execute_dict(get_indexes)
 
-		col_indexes = defaultdict(list)
-		for index in result:
-			col_indexes[index["Column_name"]].append(index)
-		self.assertGreaterEqual(len(col_indexes["id"]), 1)
-		self.assertEqual(len(col_indexes["story_id"]), 1)
+        col_indexes = defaultdict(list)
+        for index in result:
+            col_indexes[index["Column_name"]].append(index)
+        self.assertGreaterEqual(len(col_indexes["id"]), 1)
+        self.assertEqual(len(col_indexes["story_id"]), 1)
 
-	def tearDown(self):
-		drop_working = "drop database {}".format(self.args.temp_db_database)
-		self.sql.execute(drop_working)
-		drop_final = "drop database {}".format(self.args.output_database)
-		self.sql.execute(drop_final)
+    def tearDown(self):
+        drop_working = "drop database {}".format(self.args.temp_db_database)
+        self.sql.execute(drop_working)
+        drop_final = "drop database {}".format(self.args.output_database)
+        self.sql.execute(drop_final)
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()


### PR DESCRIPTION
This issue turned out to actually be expected behavior for the CREATE TABLE ... SELECT statement. Per [the official MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/create-table-select.html):

> CREATE TABLE ... SELECT does not automatically create any indexes for you. This is done intentionally to make the statement as flexible as possible.
> Some conversion of data types might occur. For example, the AUTO_INCREMENT attribute is not preserved

The documentation also shows how to add those indexes back in, so I made those changes here, and added a new statement to add the AUTO_INCREMENT back to the id.

This PR also has 2 other changes:
- ~~Before I discovered the above fact, I wondered if there was an issue with how the statements were being read. While debugging I noticed the comment regex didn't properly escape the /* characters, and from there decided to remove all the comments in the file in one go instead of doing it line-by-line.~~ I found more issues with this so I reverted the changes, but kept the new regex.
- The iteritems() to items() was a change I made to my local copy of the repo months ago when working on Chad's HP