### PR TITLE
Fix missing reference to original_table

### DIFF
--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -100,7 +100,7 @@ class Tags(object):
       SELECT DISTINCT
         id as "Original Tag ID",
         original_tag as "Original Tag Name",
-        original_type as "Original Tag Type",
+        original_table as "Original Tag Type",
         original_parent as "Original Parent Tag",
         ao3_tag_fandom as "Related Fandom",
         ao3_tag as "Recommended AO3 Tag",

--- a/test/test_data/test.sql
+++ b/test/test_data/test.sql
@@ -16,7 +16,7 @@ CREATE TABLE tags (
   `id` int NOT NULL AUTO_INCREMENT,
   `original_tagid` int DEFAULT NULL,
   `original_tag` varchar(1024) DEFAULT NULL,
-  `original_type` varchar(255) DEFAULT NULL,
+  `original_table` varchar(255) DEFAULT NULL,
   `original_parent` varchar(255) DEFAULT NULL,
   `original_description` varchar(1024) DEFAULT NULL,
   `ao3_tag` varchar(1024) DEFAULT NULL,


### PR DESCRIPTION
This was causing a failure to run step 3, as we never created the column by the name `original_type`, but instead `original_table`.