### PR TITLE
OD-1339 add choose not to warn to all works

### DIFF
--- a/shared_python/PopulateTags.py
+++ b/shared_python/PopulateTags.py
@@ -1,3 +1,7 @@
+from collections import defaultdict
+
+CNTW = "Choose Not To Use Archive Warnings"
+
 class PopulateTags(object):
   def __init__(self, args, db, log, tags, final):
     self.args = args
@@ -26,11 +30,15 @@ class PopulateTags(object):
         categories += self.valid_tags('ao3_tag_category', tag_type_tags)
         if tag_type == 'fandoms':
           fandoms += tag_list
+        if tag_type == 'warnings' and CNTW not in tag_list:
+          tag_list.append(CNTW)
         story_tags[tag_type] = ', '.join(set(tag_list))
     if not fandoms:
       fandoms = [self.args.default_fandom]
     story_tags['categories'] = ', '.join(set(categories))
     story_tags['fandoms'] = ', '.join(set(fandoms))
+    if 'warnings' not in story_tags.keys():
+      story_tags['warnings'] = CNTW
     return story_tags
 
   def write_tags_for_story(self, tags_by_story_id, item_type='story'):
@@ -39,8 +47,6 @@ class PopulateTags(object):
 
       # group tags by type into comma-separated lists
       # generate and run SQL to populate story table
-      from collections import defaultdict
-
       tags_by_type = defaultdict(list)
       for tag in story_tags:
         tags_by_type[tag['ao3_tag_type']].append(tag)

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -192,6 +192,6 @@ class Tags(object):
       cur += 1
       sys.stdout.write(f'\rCollecting tags for {item_type}: {cur}/{total}  (including Do Not Import)')
       sys.stdout.flush()
-      tags = self.sql.execute_dict(f"SELECT * FROM tags WHERE id in ({story_id[2]})")
+      tags = self.sql.execute_dict(f"SELECT * FROM tags WHERE id in ({story_id[2]}) AND ao3_tag != ''")
       tags_by_story_id[story_id[0]] = tags
     return tags_by_story_id

--- a/test/test_populate_tags.py
+++ b/test/test_populate_tags.py
@@ -38,7 +38,8 @@ class TestPopulate_tags(TestCase):
     'tags': [
       {'original_tag': 'a tag', 'ao3_tag': 'A Tag'}
     ],
-    'rating': [{'original_tag': 'PG', 'ao3_tag': 'General Audiences'}]
+    'rating': [{'original_tag': 'PG', 'ao3_tag': 'General Audiences'}],
+    'warnings': [{'original_tag': 'Violence', 'ao3_tag': 'Graphic Depictions Of Violence'}]
   }
 
   def test_default_fandom_ignored_if_fandoms_present(self):
@@ -51,6 +52,19 @@ class TestPopulate_tags(TestCase):
     story_tags = self.populate_tags.tags_for_story(1, tags_without_fandom)
     self.assertEqual('Fandom C (TV)', story_tags['fandoms'], 'Fandoms should be a comma-separated string of specified AO3 tags')
 
+  def test_cntw_added_if_warnings_present(self):
+    story_tags = self.populate_tags.tags_for_story(1, self.basic_tags)
+    self.assertCountEqual(
+      ['Graphic Depictions Of Violence', 'Choose Not To Use Archive Warnings'],
+      story_tags['warnings'].split(', '),
+      'Warnings should be a comma-separated string of AO3 warnings that includes CNTW'
+    )
+
+  def test_cntw_added_if_no_warnings_present(self):
+    tags_without_warnings = self.basic_tags.copy()
+    tags_without_warnings.pop('warnings')
+    story_tags = self.populate_tags.tags_for_story(1, tags_without_warnings)
+    self.assertEqual('Choose Not To Use Archive Warnings', story_tags['warnings'], 'Warnings should be a comma-separated string of AO3 warnings that includes CNTW')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Most of the changes here are for OD-1339. I added the ao3_tag != '' to the tag query where clause because I noticed when testing with LOTR that there was an original tag with an empty ao3_tag which was still pulled in, causing some stories to have a tag list like ", Tag 1, Tag 2, etc". This is the only context that method is invoked so I thought it was a safe change to make.