### PR TITLE
OD-1729: Allow running ODAP out of any directory

### DIFF
--- a/05-Create-Open-Doors-Tables.py
+++ b/05-Create-Open-Doors-Tables.py
@@ -37,7 +37,9 @@ def main(args, log):
     }
     filter = 'WHERE id NOT IN '
 
-    sql.run_script_from_file('shared_python/create-open-doors-tables.sql',
+    codepath  = os.path.dirname(os.path.realpath(__file__))
+
+    sql.run_script_from_file(codepath + '/shared_python/create-open-doors-tables.sql',
                              database=args.output_database)
 
     # Filter out DNI stories - story_ids_to_remove must be comma-separated list of DNI ids

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -3,6 +3,7 @@
 import datetime
 import codecs
 import re
+import os
 from html.parser import HTMLParser
 
 from pymysql import connect
@@ -115,7 +116,10 @@ def _create_mysql(args, FILES, log):
   cursor.execute(u"use {0}".format(DATABASE_NAME))
 
   sql = Sql(args)
-  sql.run_script_from_file('shared_python/create-open-doors-tables.sql', DATABASE_NAME)
+  codepath  = os.path.dirname(os.path.realpath(__file__))
+
+  sql.run_script_from_file(codepath + '/shared_python/create-open-doors-tables.sql',
+                           database=DATABASE_NAME)
   db.commit()
 
   authors = [(FILES[i].get('Author', '').strip(), FILES[i].get('Email', FILES[i].get('EmailAuthor', '')).lower().strip()) for i in FILES]


### PR DESCRIPTION
Currently, there are a few places where SQL statements are read based on the current directory ($PWD). This will cause failures when the code is not being run in the ODAP directory. Instead, always pull the path relative to the code directory.