### PR TITLE
Correct mis-indended function definition

### DIFF
--- a/shared_python/Args.py
+++ b/shared_python/Args.py
@@ -257,14 +257,15 @@ class Args(object):
         self._print_args(self.args)
         return self.args
 
-
-def args_for_08(self):
-    if self.args.output_database is None:
-        self.args.output_database = input(
-            'Name of the database the final tables should be created in (default "od_sgf"):'
-        )
-        self.args.output_database = (
-            "od_sgf" if self.args.output_database == "" else self.args.output_database
-        )
-    self._print_args(self.args)
-    return self.args
+    def args_for_08(self):
+        if self.args.output_database is None:
+            self.args.output_database = input(
+                'Name of the database the final tables should be created in (default "od_sgf"):'
+            )
+            self.args.output_database = (
+                "od_sgf"
+                if self.args.output_database == ""
+                else self.args.output_database
+            )
+            self._print_args(self.args)
+        return self.args


### PR DESCRIPTION
This fixes a crash in the step 08 script that comes from not being able to find the function in the args object.