### PR TITLE
fix: automated archive crashes

### DIFF
--- a/03-Export-Tags-Authors-Stories.py
+++ b/03-Export-Tags-Authors-Stories.py
@@ -22,6 +22,7 @@ def write_csv(data, filename, columns):
         fp.close()
 
 
+
 if __name__ == "__main__":
     """
   This step exports the Tag Wrangling and Authors with stories CSV files which you then have to import into Google

--- a/03-Export-Tags-Authors-Stories.py
+++ b/03-Export-Tags-Authors-Stories.py
@@ -22,7 +22,6 @@ def write_csv(data, filename, columns):
         fp.close()
 
 
-
 if __name__ == "__main__":
     """
   This step exports the Tag Wrangling and Authors with stories CSV files which you then have to import into Google

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -4,6 +4,7 @@ import datetime
 import codecs
 import re
 import os
+from pathlib import Path
 from html.parser import HTMLParser
 
 from pymysql import connect
@@ -123,7 +124,7 @@ def _extract_fandoms(args, record):
 
 
 def _create_mysql(args, FILES, log):
-    db = connect(args.db_host, args.db_user, args.db_password, "")
+    db = connect(host=args.db_host, user=args.db_user, password=args.db_password, db="")
     cursor = db.cursor()
     DATABASE_NAME = args.temp_db_database
 
@@ -132,12 +133,10 @@ def _create_mysql(args, FILES, log):
     cursor.execute("create database {0};".format(DATABASE_NAME))
     cursor.execute("use {0}".format(DATABASE_NAME))
 
-    sql = Sql(args)
-    codepath = os.path.dirname(os.path.realpath(__file__))
+    sql = Sql(args, log)
+    script_path = Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
 
-    sql.run_script_from_file(
-        codepath + "/shared_python/create-open-doors-tables.sql", database=DATABASE_NAME
-    )
+    sql.run_script_from_file(script_path, database=DATABASE_NAME)
     db.commit()
 
     authors = [

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -133,7 +133,9 @@ def _create_mysql(args, FILES, log):
     cursor.execute("use {0}".format(DATABASE_NAME))
 
     sql = Sql(args, log)
-    script_path = Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
+    script_path = (
+        Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
+    )
 
     sql.run_script_from_file(script_path, database=DATABASE_NAME)
     db.commit()

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -3,7 +3,6 @@
 import datetime
 import codecs
 import re
-import os
 from pathlib import Path
 from html.parser import HTMLParser
 

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -82,7 +82,7 @@ class Chapters(object):
                     # look up the author id and add that one to the file_names list
                     sql_author_id = self.sql.execute_and_fetchall(
                         self.sql.database,
-                        "SELECT author_id FROM chapters WHERE id = {0}".format(cid)
+                        "SELECT author_id FROM chapters WHERE id = {0}".format(cid),
                     )
                     if len(sql_author_id) > 0:
                         author_id = sql_author_id[0][0]

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -81,6 +81,7 @@ class Chapters(object):
                 for cid, duplicate in duplicate_chapters.items():
                     # look up the author id and add that one to the file_names list
                     sql_author_id = self.sql.execute_and_fetchall(
+                        self.sql.database,
                         "SELECT author_id FROM chapters WHERE id = {0}".format(cid)
                     )
                     if len(sql_author_id) > 0:

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -1,4 +1,6 @@
 import re
+from pathlib import Path
+from typing import Union
 import warnings
 
 # ignore unhelpful MySQL warnings
@@ -53,7 +55,7 @@ class Sql(object):
         self.conn.commit()
         return cursor.fetchall()
 
-    def run_script_from_file(self, filename, database, initial_load=False):
+    def run_script_from_file(self, filename: Union[str, Path], database, initial_load=False):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -55,7 +55,9 @@ class Sql(object):
         self.conn.commit()
         return cursor.fetchall()
 
-    def run_script_from_file(self, filename: Union[str, Path], database, initial_load=False):
+    def run_script_from_file(
+        self, filename: Union[str, Path], database, initial_load=False
+    ):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -94,7 +94,7 @@ class Tags(object):
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
                                 cleaned_tag = (
-                                    val.encode("utf-8").replace("'", "'").strip()
+                                    val.replace("'", "'").strip()
                                 )
 
                                 values.append(

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -93,9 +93,7 @@ class Tags(object):
                             if isinstance(
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
-                                cleaned_tag = (
-                                    val.replace("'", "'").strip()
-                                )
+                                cleaned_tag = val.replace("'", "'").strip()
 
                                 values.append(
                                     '({0}, "{1}", "{2}", "{3}")'.format(


### PR DESCRIPTION
- Replace the positional arguments to `pymysql.connect` with keyword arguments (it doesn't support positional arguments)
- Pass missing log parameter to `Sql` when connecting
- Fix path to initial create tables script
- `str` does not support `.encode` (it's already in UTF-8 I believe)