### PR TITLE
OD-1836 Convert Automated Archive output to working schema

### DIFF
--- a/.github/workflows/python-app-macos-windows.yml
+++ b/.github/workflows/python-app-macos-windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-13, windows-latest ] # Using macos-13 since macos-latest no longer supports 3.8
 
     steps:
       - uses: actions/checkout@v2

--- a/02b-Extract-Tags-From-Stories.py
+++ b/02b-Extract-Tags-From-Stories.py
@@ -22,7 +22,6 @@ if __name__ == "__main__":
             args.temp_db_database
         )
     )
-    tags.create_tags_table()
 
     tag_col_list = {}
     stories_id_name = ""

--- a/03-Export-Tags-Authors-Stories.py
+++ b/03-Export-Tags-Authors-Stories.py
@@ -22,6 +22,7 @@ def write_csv(data, filename, columns):
         fp.close()
 
 
+
 if __name__ == "__main__":
     """
   This step exports the Tag Wrangling and Authors with stories CSV files which you then have to import into Google

--- a/03-Export-Tags-Authors-Stories.py
+++ b/03-Export-Tags-Authors-Stories.py
@@ -22,7 +22,6 @@ def write_csv(data, filename, columns):
         fp.close()
 
 
-
 if __name__ == "__main__":
     """
   This step exports the Tag Wrangling and Authors with stories CSV files which you then have to import into Google

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -4,6 +4,7 @@ import datetime
 import codecs
 import re
 import os
+from pathlib import Path
 from html.parser import HTMLParser
 
 from pymysql import connect
@@ -123,7 +124,7 @@ def _extract_fandoms(args, record):
 
 
 def _create_mysql(args, FILES, log):
-    db = connect(args.db_host, args.db_user, args.db_password, "")
+    db = connect(host=args.db_host, user=args.db_user, password=args.db_password, db="")
     cursor = db.cursor()
     DATABASE_NAME = args.temp_db_database
 
@@ -132,12 +133,10 @@ def _create_mysql(args, FILES, log):
     cursor.execute("create database {0};".format(DATABASE_NAME))
     cursor.execute("use {0}".format(DATABASE_NAME))
 
-    sql = Sql(args)
-    codepath = os.path.dirname(os.path.realpath(__file__))
+    sql = Sql(args, log)
+    script_path = Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
 
-    sql.run_script_from_file(
-        codepath + "/shared_python/create-open-doors-tables.sql", database=DATABASE_NAME
-    )
+    sql.run_script_from_file(script_path, database=DATABASE_NAME)
     db.commit()
 
     authors = [

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -133,7 +133,9 @@ def _create_mysql(args, FILES, log):
     cursor.execute("use {0}".format(DATABASE_NAME))
 
     sql = Sql(args, log)
-    script_path = Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
+    script_path = (
+        Path(__file__).parent.parent / "shared_python" / "create-open-doors-tables.sql"
+    )
 
     sql.run_script_from_file(script_path, database=DATABASE_NAME)
     db.commit()

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -22,16 +22,10 @@ def _clean_file(filepath, log):
     :param filepath: Path to ARCHIVE_DB.pl
     :return: Python dictionary keyed by original story id
     """
-    for i, encoding in enumerate(["utf-8", "ascii", "Latin-1", "Windows-1252"]):
-        try:
-            archive_db = codecs.open(filepath, "r", encoding=encoding).read()
-            break
-        except:  # noqa: E722
-            log.error(f"{encoding} encoding failed to read ARCHIVE_DB.pl")
-            if i == 3:
-                raise RuntimeError(
-                    "ARCHIVE_DB.pl can't be read by any of the default encodings, please fix the file and try again."
-                )
+    encoding = input('Encoding for the ARCHIVE_DB.pl file (default: "utf-8"): ')
+    if encoding is None or encoding == "":
+        encoding = "utf-8"
+    archive_db = codecs.open(filepath, "r", encoding=encoding).read()
 
     # Manually escape single quote entity and reformat file as a Python dictionary
     step1 = html.unescape(archive_db.replace("&#39;", "\\&#39;"))

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -3,7 +3,6 @@
 import datetime
 import codecs
 import re
-import os
 from pathlib import Path
 from html.parser import HTMLParser
 

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -22,7 +22,7 @@ def _clean_file(filepath, log):
     :param filepath: Path to ARCHIVE_DB.pl
     :return: Python dictionary keyed by original story id
     """
-    encoding = input('Encoding for the ARCHIVE_DB.pl file (default: "utf-8"): ')
+    encoding = input('Encoding for the ARCHIVE_DB.pl file, e.g. "utf-8", "latin_1", "cp1252" (default: "utf-8"): ')
     if encoding is None or encoding == "":
         encoding = "utf-8"
     archive_db = codecs.open(filepath, "r", encoding=encoding).read()

--- a/automated_archive/aa.py
+++ b/automated_archive/aa.py
@@ -22,7 +22,9 @@ def _clean_file(filepath, log):
     :param filepath: Path to ARCHIVE_DB.pl
     :return: Python dictionary keyed by original story id
     """
-    encoding = input('Encoding for the ARCHIVE_DB.pl file, e.g. "utf-8", "latin_1", "cp1252" (default: "utf-8"): ')
+    encoding = input(
+        'Encoding for the ARCHIVE_DB.pl file, e.g. "utf-8", "latin_1", "cp1252" (default: "utf-8"): '
+    )
     if encoding is None or encoding == "":
         encoding = "utf-8"
     archive_db = codecs.open(filepath, "r", encoding=encoding).read()

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -82,7 +82,7 @@ class Chapters(object):
                     # look up the author id and add that one to the file_names list
                     sql_author_id = self.sql.execute_and_fetchall(
                         self.sql.database,
-                        "SELECT author_id FROM chapters WHERE id = {0}".format(cid)
+                        "SELECT author_id FROM chapters WHERE id = {0}".format(cid),
                     )
                     if len(sql_author_id) > 0:
                         author_id = sql_author_id[0][0]

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -81,6 +81,7 @@ class Chapters(object):
                 for cid, duplicate in duplicate_chapters.items():
                     # look up the author id and add that one to the file_names list
                     sql_author_id = self.sql.execute_and_fetchall(
+                        self.sql.database,
                         "SELECT author_id FROM chapters WHERE id = {0}".format(cid)
                     )
                     if len(sql_author_id) > 0:

--- a/shared_python/Chapters.py
+++ b/shared_python/Chapters.py
@@ -143,6 +143,8 @@ class Chapters(object):
         else:
             for _, chapter_path in file_paths.items():
                 path = chapter_path.replace(self.args.chapters_path, "")[1:]
+                if os.sep == "\\":  # if this script is run on windows
+                    path = path.replace("\\", "/")
                 with codecs.open(chapter_path, "r", encoding=char_encoding) as c:
                     try:
                         cur = Common.print_progress(cur, total)

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -1,4 +1,6 @@
 import re
+from pathlib import Path
+from typing import Union
 import warnings
 
 # ignore unhelpful MySQL warnings
@@ -53,7 +55,7 @@ class Sql(object):
         self.conn.commit()
         return cursor.fetchall()
 
-    def run_script_from_file(self, filename, database, initial_load=False):
+    def run_script_from_file(self, filename: Union[str, Path], database, initial_load=False):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -53,18 +53,14 @@ class Sql(object):
         self.conn.commit()
         return cursor.fetchall()
 
-    def run_script_from_file(
-        self, filename, database, initial_load=False
-    ):
+    def run_script_from_file(self, filename, database, initial_load=False):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()
         fd.close()
         self.run_sql_file(sqlFile, database, initial_load)
 
-    def run_sql_file(
-        self, sqlFile, database, initial_load=False
-    ):
+    def run_sql_file(self, sqlFile, database, initial_load=False):
         # replace placeholders and return all SQL commands (split on ';')
         sqlCommands = sqlFile.replace("$DATABASE$", database).split(";\n")
 

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -55,7 +55,9 @@ class Sql(object):
         self.conn.commit()
         return cursor.fetchall()
 
-    def run_script_from_file(self, filename: Union[str, Path], database, initial_load=False):
+    def run_script_from_file(
+        self, filename: Union[str, Path], database, initial_load=False
+    ):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()

--- a/shared_python/Sql.py
+++ b/shared_python/Sql.py
@@ -1,6 +1,4 @@
 import re
-from pathlib import Path
-from typing import Union
 import warnings
 
 # ignore unhelpful MySQL warnings
@@ -56,13 +54,17 @@ class Sql(object):
         return cursor.fetchall()
 
     def run_script_from_file(
-        self, filename: Union[str, Path], database, initial_load=False
+        self, filename, database, initial_load=False
     ):
         # Open and read the file as a single buffer
         fd = open(filename, "r")
         sqlFile = fd.read()
         fd.close()
+        self.run_sql_file(sqlFile, database, initial_load)
 
+    def run_sql_file(
+        self, sqlFile, database, initial_load=False
+    ):
         # replace placeholders and return all SQL commands (split on ';')
         sqlCommands = sqlFile.replace("$DATABASE$", database).split(";\n")
 

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -96,7 +96,9 @@ class Tags(object):
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
                                 cleaned_tag = re.sub(
-                                    r'(?<!\\)"', '\\"', val.replace("'", "'").strip()
+                                    r'(?<!\\)"',
+                                    '\\"',
+                                    val.replace("'", "'").strip(),
                                 )
                                 tags_to_story_ids[cleaned_tag].append(
                                     story_tags_row[story_id_col_name]

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -1,4 +1,5 @@
 import re
+from collections import defaultdict
 from html.parser import HTMLParser
 from logging import Logger
 
@@ -83,8 +84,9 @@ class Tags(object):
             )
         )
 
+        tags_to_insert = {}
+        tags_to_story_ids = defaultdict(list)
         for story_tags_row in data:
-            values = []
             for col in tag_columns:
                 needs_fandom = col in tags_with_fandoms
                 if story_tags_row[col] is not None:
@@ -93,25 +95,36 @@ class Tags(object):
                             if isinstance(
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
-                                cleaned_tag = val.replace("'", "'").strip()
-
-                                values.append(
-                                    '({0}, "{1}", "{2}", "{3}")'.format(
-                                        story_tags_row[story_id_col_name],
-                                        re.sub(r'(?<!\\)"', '\\"', cleaned_tag),
+                                cleaned_tag = re.sub(r'(?<!\\)"', '\\"', val.replace("'", "'").strip())
+                                tags_to_story_ids[cleaned_tag].append(story_tags_row[story_id_col_name])
+                                tags_to_insert[cleaned_tag] = '("{0}", "{1}", "{2}")'.format(
+                                        cleaned_tag,
                                         tag_col_lookup[col],
                                         story_tags_row["fandoms"]
                                         if needs_fandom
                                         else "",
-                                    )
                                 )
 
-            if len(values) > 0:
-                self.sql.execute(
-                    """
-               INSERT INTO tags (storyid, original_tag, original_table, ao3_tag_fandom) VALUES {0}
-             """.format(", ".join(values))
-                )
+        if len(tags_to_insert) > 0:
+            self.sql.execute(
+                """
+           INSERT INTO tags (original_tag, original_type, ao3_tag_fandom) VALUES {0}
+         """.format(", ".join(tags_to_insert.values()))
+            )
+            
+            tag_data = self.sql.execute_dict(
+                "SELECT id, original_tag FROM tags"
+            )
+            for tag_row in tag_data:
+                story_ids = set(tags_to_story_ids[tag_row["original_tag"]])
+                for story_id in story_ids:
+                    self.sql.execute("""
+                    INSERT INTO item_tags (item_id, item_type, tag_id) VALUES ({0}, "{1}", {2})
+                    """.format(
+                        story_id,
+                        "story_link" if table_name == "story_links" else "story",
+                        tag_row["id"]
+                    ))
 
     def distinct_tags(self, database):
         """

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -94,7 +94,7 @@ class Tags(object):
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
                                 cleaned_tag = (
-                                    val.encode("utf-8").replace("'", "'").strip()
+                                    val.replace("'", "'").strip()
                                 )
 
                                 values.append(

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -93,9 +93,7 @@ class Tags(object):
                             if isinstance(
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
-                                cleaned_tag = (
-                                    val.replace("'", "'").strip()
-                                )
+                                cleaned_tag = val.replace("'", "'").strip()
 
                                 values.append(
                                     '({0}, "{1}", "{2}", "{3}")'.format(

--- a/shared_python/Tags.py
+++ b/shared_python/Tags.py
@@ -95,14 +95,18 @@ class Tags(object):
                             if isinstance(
                                 tag_col_lookup[col], str
                             ):  # Probably AA or a custom archive
-                                cleaned_tag = re.sub(r'(?<!\\)"', '\\"', val.replace("'", "'").strip())
-                                tags_to_story_ids[cleaned_tag].append(story_tags_row[story_id_col_name])
-                                tags_to_insert[cleaned_tag] = '("{0}", "{1}", "{2}")'.format(
-                                        cleaned_tag,
-                                        tag_col_lookup[col],
-                                        story_tags_row["fandoms"]
-                                        if needs_fandom
-                                        else "",
+                                cleaned_tag = re.sub(
+                                    r'(?<!\\)"', '\\"', val.replace("'", "'").strip()
+                                )
+                                tags_to_story_ids[cleaned_tag].append(
+                                    story_tags_row[story_id_col_name]
+                                )
+                                tags_to_insert[
+                                    cleaned_tag
+                                ] = '("{0}", "{1}", "{2}")'.format(
+                                    cleaned_tag,
+                                    tag_col_lookup[col],
+                                    story_tags_row["fandoms"] if needs_fandom else "",
                                 )
 
         if len(tags_to_insert) > 0:
@@ -111,20 +115,20 @@ class Tags(object):
            INSERT INTO tags (original_tag, original_type, ao3_tag_fandom) VALUES {0}
          """.format(", ".join(tags_to_insert.values()))
             )
-            
-            tag_data = self.sql.execute_dict(
-                "SELECT id, original_tag FROM tags"
-            )
+
+            tag_data = self.sql.execute_dict("SELECT id, original_tag FROM tags")
             for tag_row in tag_data:
                 story_ids = set(tags_to_story_ids[tag_row["original_tag"]])
                 for story_id in story_ids:
-                    self.sql.execute("""
+                    self.sql.execute(
+                        """
                     INSERT INTO item_tags (item_id, item_type, tag_id) VALUES ({0}, "{1}", {2})
                     """.format(
-                        story_id,
-                        "story_link" if table_name == "story_links" else "story",
-                        tag_row["id"]
-                    ))
+                            story_id,
+                            "story_link" if table_name == "story_links" else "story",
+                            tag_row["id"],
+                        )
+                    )
 
     def distinct_tags(self, database):
         """


### PR DESCRIPTION
There are a few changes here so that ODAP can process an Automated Archive like Unit B, and also that the end result is the same working schema that is the output of the eFiction repo so it can be fed into steps 3-6.

Conversion to working schema changes
- Use the working sql file from the eFiction repo as the starting point for the database. I didn't want to replicate the file in this repo so the script uses a GET request. If there are better ways to handle this I can make updates
- Insert _item_authors_ rows to record the relationships between stories and authors
- Insert unique tags into the _tags_ table then insert _item_tags_ rows to record the relationships between stories and tags

Changes due to issues processing Unit B
- Its ARCHIVE_DB.pl file was not utf-8 encoded but latin-1 encoded, so it prompts for the encoding of the file
- The values in the Date field were Unix timestamps not datetime strings so it checks whether the date is in the Unix timestamp format
- The chapter URLs (the Location field) included "/", example "5/heatenough.html", which caused an issue since I was running the script on windows and the files were downloaded locally. So it corrects for this issue if it's run on windows.

Other
- Since [the other PR](https://github.com/otwcode/open-doors-code/pull/83) had an issue with the github workflows I tried to fix that here.